### PR TITLE
Bump hyprland to 0.37.1

### DIFF
--- a/void/common/shlibs
+++ b/void/common/shlibs
@@ -1,3 +1,4 @@
+libhyprcursor.so.0 hyprcursor-0.1.4_1
+libhyprlang.so.2 hyprlang-0.5.0_1
 libsdbus-c++.so.1 sdbus-cpp-1.4.0_1
-libhyprlang.so.1 hyprlang-0.4.1_1
 libtomlplusplus.so.3 tomlplusplus-3.4.0_1

--- a/void/srcpkgs/hyprcursor/template
+++ b/void/srcpkgs/hyprcursor/template
@@ -1,0 +1,17 @@
+# Template file for 'hyprcursor'
+pkgname=hyprcursor
+version=0.1.4
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config cairo-devel"
+makedepends="hyprlang librsvg-devel libzip-devel"
+short_desc="Hyprland cursor format, library and utilities"
+maintainer="zenobit <zenobit@disroot.org>"
+license="BSD-3-Clause"
+homepage="https://github.com/hyprwm/hyprcursor"
+distfiles="https://github.com/hyprwm/hyprcursor/archive/refs/tags/v${version}.tar.gz"
+checksum=082c7866a8139993be0c476873dafea357bb579c8d1839280be6bfdef3177193
+
+post_install() {
+	vlicense LICENSE
+}

--- a/void/srcpkgs/hyprland-protocols/template
+++ b/void/srcpkgs/hyprland-protocols/template
@@ -7,8 +7,8 @@ hostmakedepends="wayland-devel"
 makedepends="wayland-devel"
 short_desc="Wayland protocol extensions for Hyprland"
 maintainer="Makrennel <makrommel@protonmail.ch>"
-license="BSD"
-homepage="https://github.com/hyprwm/${pkgname}"
+license="BSD-3-Clause"
+homepage="https://github.com/hyprwm/hyprland-protocols"
 distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
 checksum=106cb189d0fbe4ec0ee11a12a17238172f4c4cd1b2b26db904df144e5c7a05f0
 

--- a/void/srcpkgs/hyprland/template
+++ b/void/srcpkgs/hyprland/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprland'
 pkgname=hyprland
-version=0.36.0
+version=0.37.1
 revision=1
 hostmakedepends="
 	cmake
@@ -15,6 +15,7 @@ hostmakedepends="
 "
 makedepends="
 	cairo-devel
+        hyprcursor
 	hyprlang
 	libdisplay-info-devel
 	libdrm-devel
@@ -40,7 +41,7 @@ license="BSD-3-Clause"
 homepage="https://hyprland.org/"
 changelog="https://github.com/hyprwm/Hyprland/releases"
 distfiles="https://github.com/hyprwm/Hyprland/releases/download/v${version}/source-v${version}.tar.gz"
-checksum=8e44c379794663accf928458b5e363ed248d56fc5f267e6b3759146fdf1229bb
+checksum=bf3c33f7643218af3c44411c28e9a20fcd02225e56d732a8a4a446d9a298f862
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
 	makedepends+=" libexecinfo-devel"

--- a/void/srcpkgs/hyprlang/template
+++ b/void/srcpkgs/hyprlang/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprlang'
 pkgname=hyprlang
-version=0.4.1
+version=0.5.0
 revision=1
 build_style=cmake
 hostmakedepends="cmake pkg-config"
@@ -10,4 +10,4 @@ license="LGPL-3.0-only"
 homepage="https://hyprland.org/hyprlang/index.html"
 changelog="https://github.com/hyprwm/hyprlang/releases"
 distfiles="https://github.com/hyprwm/hyprlang/archive/refs/tags/v${version}.tar.gz"
-checksum=dd00b48fc31199c3f30f4ef6ec61f3bddcc092eff2628ee28cb238a4501521e8
+checksum=c59e705f2c2ff9ea4e2b183fdf0bc20a62b7162604a657d6352716a1fd5061b2

--- a/void/srcpkgs/hyprlock/template
+++ b/void/srcpkgs/hyprlock/template
@@ -8,7 +8,11 @@ makedepends="cairo-devel hyprlang libdrm-devel libxkbcommon-devel MesaLib-devel 
 short_desc="Hyprland's GPU-accelerated screen locking utility"
 maintainer="Makrennel <makrommel@protonmail.ch>"
 license="BSD-3-Clause"
-homepage="https://github.com/hyprwm/${pkgname}"
+homepage="https://github.com/hyprwm/hyprlock"
 changelog="https://github.com/hyprwm/${pkgname}/releases"
 distfiles="https://github.com/hyprwm/${pkgname}/archive/refs/tags/v${version}.tar.gz"
 checksum=5d0e6547ac073c78e95d4f086a258e1e5713168827c38ccb2466f2c4d96bd1df
+
+post_install() {
+	vlicense LICENSE
+}


### PR DESCRIPTION
This PR adds:
- new package `hyprcursor`
- updated version of `hyprlang`
- SONAME updates